### PR TITLE
Filter out directories in the glob

### DIFF
--- a/lib/test_summary_buildkite_plugin/input.rb
+++ b/lib/test_summary_buildkite_plugin/input.rb
@@ -38,7 +38,8 @@ module TestSummaryBuildkitePlugin
         @files ||= begin
           FileUtils.mkpath(WORKDIR)
           Agent.run('artifact', 'download', artifact_path, WORKDIR)
-          Dir.glob("#{WORKDIR}/**/*")
+          f = Dir.glob("#{WORKDIR}/**/*")
+          f.filter { |filepath| File.file?(filepath) }
         rescue Agent::CommandFailed => err
           if fail_on_error
             raise

--- a/lib/test_summary_buildkite_plugin/input.rb
+++ b/lib/test_summary_buildkite_plugin/input.rb
@@ -39,7 +39,7 @@ module TestSummaryBuildkitePlugin
           FileUtils.mkpath(WORKDIR)
           Agent.run('artifact', 'download', artifact_path, WORKDIR)
           f = Dir.glob("#{WORKDIR}/**/*")
-          f.filter { |filepath| File.file?(filepath) }
+          f.select { |filepath| File.file?(filepath) }
         rescue Agent::CommandFailed => err
           if fail_on_error
             raise


### PR DESCRIPTION
Missed this when testing against the GDK for Unity repo since we only have logs in the root dir and there are no sub-dirs due to the artifact path squashing in Windows -> Linux. 

Now we filter out non-files. 